### PR TITLE
style(onechunk): use blanks instead of tabs for spacing.

### DIFF
--- a/Pieces/ChestCorridor.h
+++ b/Pieces/ChestCorridor.h
@@ -7,34 +7,34 @@
 
 class ChestCorridor : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 7, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(CHESTCORRIDOR_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(CHESTCORRIDOR_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 7, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(CHESTCORRIDOR_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(CHESTCORRIDOR_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
+    }
 };
 #endif

--- a/Pieces/Corridor.h
+++ b/Pieces/Corridor.h
@@ -7,37 +7,37 @@
 
 class Corridor : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 4, coordBaseMode);
-		
-		BoundingBox intersection = StrongholdPiece::findIntersecting(data, var7);
-		if(intersection.start.x == -133769) {
-			var7.start.y = -64;
-		}
-		else {
-			if (intersection.start.y == var7.start.y)
-			{
-				for (int var9 = 3; var9 >= 1; --var9)
-				{
-					var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, var9 - 1, coordBaseMode);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 4, coordBaseMode);
+        
+        BoundingBox intersection = StrongholdPiece::findIntersecting(data, var7);
+        if(intersection.start.x == -133769) {
+            var7.start.y = -64;
+        }
+        else {
+            if (intersection.start.y == var7.start.y)
+            {
+                for (int var9 = 3; var9 >= 1; --var9)
+                {
+                    var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, var9 - 1, coordBaseMode);
 
-					if (!intersection.intersectsWith(&var7))
-					{
-						var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, var9, coordBaseMode);
-						//removed2
-			
-						data->addPiece(CORRIDOR_PIECE, coordBaseMode, BFSlayer, var7);
-						data->addPiecePending(CORRIDOR_PIECE, coordBaseMode, BFSlayer, var7);
-						
-						return var7;
-					}
-				}
-			}
+                    if (!intersection.intersectsWith(&var7))
+                    {
+                        var7 = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, var9, coordBaseMode);
+                        //removed2
+            
+                        data->addPiece(CORRIDOR_PIECE, coordBaseMode, BFSlayer, var7);
+                        data->addPiecePending(CORRIDOR_PIECE, coordBaseMode, BFSlayer, var7);
+                        
+                        return var7;
+                    }
+                }
+            }
 
-			var7.start.y = -64;
-		}
-		return var7;
-	}
+            var7.start.y = -64;
+        }
+        return var7;
+    }
 };
 #endif

--- a/Pieces/Crossing.h
+++ b/Pieces/Crossing.h
@@ -7,69 +7,69 @@
 
 class Crossing : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -3, 0, 10, 9, 11, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->pieces_pending[data->pendingCnt].pieceID = data->pieceCnt;
-			data->addPiece(CROSSING_PIECE, coordBaseMode, BFSlayer, box);
-			
-			//std::cout << "randomDoor: " << data->rng->nextInt(5) << std::endl; //getRandomDoor
-			data->rng->nextInt(5);
-			
-			bool field1 = data->rng->nextBoolean();
-			bool field2 = data->rng->nextBoolean();
-			bool field3 = data->rng->nextBoolean();
-			bool field4 = data->rng->nextInt(3) > 0;
-			
-			data->addPiecePending(CROSSING_PIECE, coordBaseMode, BFSlayer, box, field1, field2, field3, field4);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -3, 0, 10, 9, 11, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->pieces_pending[data->pendingCnt].pieceID = data->pieceCnt;
+            data->addPiece(CROSSING_PIECE, coordBaseMode, BFSlayer, box);
+            
+            //std::cout << "randomDoor: " << data->rng->nextInt(5) << std::endl; //getRandomDoor
+            data->rng->nextInt(5);
+            
+            bool field1 = data->rng->nextBoolean();
+            bool field2 = data->rng->nextBoolean();
+            bool field3 = data->rng->nextBoolean();
+            bool field4 = data->rng->nextInt(3) > 0;
+            
+            data->addPiecePending(CROSSING_PIECE, coordBaseMode, BFSlayer, box, field1, field2, field3, field4);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		//std::cout << " MY NAME JEFF " << std::endl;
-		int var4 = 3;
-		int var5 = 5;
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        //std::cout << " MY NAME JEFF " << std::endl;
+        int var4 = 3;
+        int var5 = 5;
 
-		if (thisPiece.coordBaseMode == 1 || thisPiece.coordBaseMode == 2)
-		{
-		  var4 = 8 - var4;
-		  var5 = 8 - var5;
-		}
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 5, 1);
-		
-		if(thisPiece.field1) {
-			//std::cout << "special 3" << std::endl;
-			StrongholdPiece::getNextComponentX(data, thisPiece, var4, 1);
-		}
-		
-		if(thisPiece.field2) {
-			//std::cout << "special 4" << std::endl;
-			StrongholdPiece::getNextComponentX(data, thisPiece, var5, 7);
-		}
-		
-		if(thisPiece.field3) {
-			//std::cout << "special 5" << std::endl;
-			StrongholdPiece::getNextComponentZ(data, thisPiece, var4, 1);
-		}
-		
-		if(thisPiece.field4) {
-			//std::cout << "special 6" << std::endl;
-			StrongholdPiece::getNextComponentZ(data, thisPiece, var5, 7);
-		}
-	}
+        if (thisPiece.coordBaseMode == 1 || thisPiece.coordBaseMode == 2)
+        {
+          var4 = 8 - var4;
+          var5 = 8 - var5;
+        }
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 5, 1);
+        
+        if(thisPiece.field1) {
+            //std::cout << "special 3" << std::endl;
+            StrongholdPiece::getNextComponentX(data, thisPiece, var4, 1);
+        }
+        
+        if(thisPiece.field2) {
+            //std::cout << "special 4" << std::endl;
+            StrongholdPiece::getNextComponentX(data, thisPiece, var5, 7);
+        }
+        
+        if(thisPiece.field3) {
+            //std::cout << "special 5" << std::endl;
+            StrongholdPiece::getNextComponentZ(data, thisPiece, var4, 1);
+        }
+        
+        if(thisPiece.field4) {
+            //std::cout << "special 6" << std::endl;
+            StrongholdPiece::getNextComponentZ(data, thisPiece, var5, 7);
+        }
+    }
 };
 #endif

--- a/Pieces/LeftTurn.h
+++ b/Pieces/LeftTurn.h
@@ -7,45 +7,45 @@
 
 class LeftTurn : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 5, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(LEFTTURN_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(LEFTTURN_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 5, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(LEFTTURN_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(LEFTTURN_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		//std::cout << " MY NAME JEFF2 " << std::endl;
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        //std::cout << " MY NAME JEFF2 " << std::endl;
 
-		if (thisPiece.coordBaseMode != 2 && thisPiece.coordBaseMode != 3)
-		{
-			StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 1);
-		}
-		else
-		{
-			StrongholdPiece::getNextComponentX(data, thisPiece, 1, 1);
-		  //std::cout << "here." << std::endl;
-			//this->getNextComponentZ(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
-		}
-	}
+        if (thisPiece.coordBaseMode != 2 && thisPiece.coordBaseMode != 3)
+        {
+            StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 1);
+        }
+        else
+        {
+            StrongholdPiece::getNextComponentX(data, thisPiece, 1, 1);
+          //std::cout << "here." << std::endl;
+            //this->getNextComponentZ(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
+        }
+    }
 };
 #endif

--- a/Pieces/Library.h
+++ b/Pieces/Library.h
@@ -7,38 +7,38 @@
 
 class Library : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 14, 11, 15, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 14, 6, 15, coordBaseMode);
-			
-			if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-				//removed1
-				box.start.y = -64;
-			}
-		}
-		
-		if(box.start.y != -64) {
-			//removed2
-			
-			data->addPiece(LIBRARY_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(LIBRARY_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 14, 11, 15, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 14, 6, 15, coordBaseMode);
+            
+            if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+                //removed1
+                box.start.y = -64;
+            }
+        }
+        
+        if(box.start.y != -64) {
+            //removed2
+            
+            data->addPiece(LIBRARY_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(LIBRARY_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+    }
 };
 #endif

--- a/Pieces/PortalRoom.h
+++ b/Pieces/PortalRoom.h
@@ -7,33 +7,33 @@
 
 class PortalRoom : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 11, 8, 16, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//std::cout << "Found it! boom. Box: " << box.getStr() << std::endl;
-			
-			
-			data->addPiece(PORTALROOM_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->portalFound = true;
-			//data->addPiecePending(PORTALROOM_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 11, 8, 16, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //std::cout << "Found it! boom. Box: " << box.getStr() << std::endl;
+            
+            
+            data->addPiece(PORTALROOM_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->portalFound = true;
+            //data->addPiecePending(PORTALROOM_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+    }
 };
 #endif

--- a/Pieces/Prison.h
+++ b/Pieces/Prison.h
@@ -7,34 +7,34 @@
 
 class Prison : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 9, 5, 11, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(PRISON_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(PRISON_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 9, 5, 11, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(PRISON_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(PRISON_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
+    }
 };
 #endif

--- a/Pieces/RightTurn.h
+++ b/Pieces/RightTurn.h
@@ -7,46 +7,46 @@
 
 class RightTurn : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 5, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(RIGHTTURN_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(RIGHTTURN_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 5, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(RIGHTTURN_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(RIGHTTURN_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		//std::cout << " MY NAME JEFF2 - " << thisPiece.coordBaseMode << std::endl;
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        //std::cout << " MY NAME JEFF2 - " << thisPiece.coordBaseMode << std::endl;
 
-		if (thisPiece.coordBaseMode != 2 && thisPiece.coordBaseMode != 3)
-		{
-			StrongholdPiece::getNextComponentX(data, thisPiece, 1, 1);
-			//this->getNextComponentX(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
-		}
-		else
-		{
-			StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 1);
-		  //std::cout << "here." << std::endl;
-			//this->getNextComponentZ(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
-		}
-	}
+        if (thisPiece.coordBaseMode != 2 && thisPiece.coordBaseMode != 3)
+        {
+            StrongholdPiece::getNextComponentX(data, thisPiece, 1, 1);
+            //this->getNextComponentX(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
+        }
+        else
+        {
+            StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 1);
+          //std::cout << "here." << std::endl;
+            //this->getNextComponentZ(pieces, pieces_pending, rng, 1, 1, this->BFSlayer, strongComponentType, totalWeight, piecesWeight, strongholdPieceWeight);
+        }
+    }
 };
 #endif

--- a/Pieces/RoomCrossing.h
+++ b/Pieces/RoomCrossing.h
@@ -7,37 +7,37 @@
 
 class RoomCrossing : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 11, 7, 11, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(ROOMCROSSING_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			data->rng->nextInt(5); //room type (?)
-			
-			data->addPiecePending(ROOMCROSSING_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -4, -1, 0, 11, 7, 11, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(ROOMCROSSING_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            data->rng->nextInt(5); //room type (?)
+            
+            data->addPiecePending(ROOMCROSSING_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 4, 1);
-		StrongholdPiece::getNextComponentX(data, thisPiece, 1, 4);
-		StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 4);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 4, 1);
+        StrongholdPiece::getNextComponentX(data, thisPiece, 1, 4);
+        StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 4);
+    }
 };
 #endif

--- a/Pieces/Stairs.h
+++ b/Pieces/Stairs.h
@@ -7,34 +7,34 @@
 
 class Stairs : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -7, 0, 5, 11, 5, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(STAIRS_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(STAIRS_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -7, 0, 5, 11, 5, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(STAIRS_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(STAIRS_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
+    }
 };
 #endif

--- a/Pieces/Stairs2.h
+++ b/Pieces/Stairs2.h
@@ -6,18 +6,18 @@
 
 class Stairs2 : public StrongholdPiece {
 public:
-	static void GeneratePiece(Data* data) {
-		BoundingBox box;
-		int x = (data->StartChunkX << 4) + 2;
-		int z = (data->StartChunkZ << 4) + 2;
-		
-		box.setAll(x, 64, z, x + 4, 74, z + 4);
-		
-		data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);
-	}
-	
-	static void BuildComponent(Data* data) {
-		StrongholdPiece::getNextComponentNormal(data, data->pieces[0], 1, 1);
-	}
+    static void GeneratePiece(Data* data) {
+        BoundingBox box;
+        int x = (data->StartChunkX << 4) + 2;
+        int z = (data->StartChunkZ << 4) + 2;
+        
+        box.setAll(x, 64, z, x + 4, 74, z + 4);
+        
+        data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);
+    }
+    
+    static void BuildComponent(Data* data) {
+        StrongholdPiece::getNextComponentNormal(data, data->pieces[0], 1, 1);
+    }
 };
 #endif

--- a/Pieces/StairsStraight.h
+++ b/Pieces/StairsStraight.h
@@ -7,34 +7,34 @@
 
 class StairsStraight : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -7, 0, 5, 11, 8, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(STAIRSSTRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			
-			data->addPiecePending(STAIRSSTRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -7, 0, 5, 11, 8, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(STAIRSSTRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            
+            data->addPiecePending(STAIRSSTRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
+    }
 };
 #endif

--- a/Pieces/Straight.h
+++ b/Pieces/Straight.h
@@ -7,39 +7,39 @@
 
 class Straight : public StrongholdPiece {
 public:
-	static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-		//removed3
-		BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 7, coordBaseMode);
-		if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
-			//removed1
-			box.start.y = -64;
-		}
-		else {
-			//removed2
-			
-			data->addPiece(STRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
-			
-			data->rng->nextInt(5); //getRandomDoor
-			bool field1 = data->rng->nextInt(2) == 0;
-			bool field2 = data->rng->nextInt(2) == 0;
-			
-			data->addPiecePending(STRAIGHT_PIECE, coordBaseMode, BFSlayer, box, field1, field2);
+    static BoundingBox GeneratePiece(Data* data, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
+        //removed3
+        BoundingBox box = BoundingBox::getComponentToAddBoundingBox(x1, y1, z1, -1, -1, 0, 5, 5, 7, coordBaseMode);
+        if(box.start.x == -133769 || StrongholdPiece::findIntersecting(data, box).start.x != -133769) {
+            //removed1
+            box.start.y = -64;
+        }
+        else {
+            //removed2
+            
+            data->addPiece(STRAIGHT_PIECE, coordBaseMode, BFSlayer, box);
+            
+            data->rng->nextInt(5); //getRandomDoor
+            bool field1 = data->rng->nextInt(2) == 0;
+            bool field2 = data->rng->nextInt(2) == 0;
+            
+            data->addPiecePending(STRAIGHT_PIECE, coordBaseMode, BFSlayer, box, field1, field2);
 
-			/*int x = (data->StartChunkX << 4) + 2;
-			int z = (data->StartChunkZ << 4) + 2;
-			
-			box.setAll(x, 64, z, x + 4, 74, z + 4);
-			
-			data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
-		}
-		return box;
-	}
-	
-	static void BuildComponent(Data* data, PieceInfo thisPiece) {
-		StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
-		
-		if(thisPiece.field1) StrongholdPiece::getNextComponentX(data, thisPiece, 1, 2);
-		if(thisPiece.field2) StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 2);
-	}
+            /*int x = (data->StartChunkX << 4) + 2;
+            int z = (data->StartChunkZ << 4) + 2;
+            
+            box.setAll(x, 64, z, x + 4, 74, z + 4);
+            
+            data->addPiece(STAIRS2_PIECE, data->rng->nextInt(4), 0, box);*/
+        }
+        return box;
+    }
+    
+    static void BuildComponent(Data* data, PieceInfo thisPiece) {
+        StrongholdPiece::getNextComponentNormal(data, thisPiece, 1, 1);
+        
+        if(thisPiece.field1) StrongholdPiece::getNextComponentX(data, thisPiece, 1, 2);
+        if(thisPiece.field2) StrongholdPiece::getNextComponentZ(data, thisPiece, 1, 2);
+    }
 };
 #endif

--- a/Pieces/Stronghold.cpp
+++ b/Pieces/Stronghold.cpp
@@ -15,130 +15,130 @@
 #include <iostream>
 
 bool getStrongholdComponentFromWeightedPiece(Data* data, int componentType, int x1, int y1, int z1, int coordBaseMode, int BFSlayer) {
-	BoundingBox box;
-	box.start.y = -64;
-	
-	if(componentType == CROSSING_PIECE) box = Crossing::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == LEFTTURN_PIECE) box = LeftTurn::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == STRAIGHT_PIECE) box = Straight::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == STAIRSSTRAIGHT_PIECE) box = StairsStraight::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == STAIRS_PIECE) box = Stairs::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == PRISON_PIECE) box = Prison::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == PORTALROOM_PIECE) box = PortalRoom::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	//WTF SPAGHETTI CODE
-	else if(componentType == RIGHTTURN_PIECE) box = LeftTurn::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == CHESTCORRIDOR_PIECE) box = ChestCorridor::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == ROOMCROSSING_PIECE) box = RoomCrossing::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	else if(componentType == LIBRARY_PIECE) box = Library::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	
-	if(box.start.y == -64) return false;
-	
-	return true;
+    BoundingBox box;
+    box.start.y = -64;
+    
+    if(componentType == CROSSING_PIECE) box = Crossing::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == LEFTTURN_PIECE) box = LeftTurn::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == STRAIGHT_PIECE) box = Straight::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == STAIRSSTRAIGHT_PIECE) box = StairsStraight::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == STAIRS_PIECE) box = Stairs::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == PRISON_PIECE) box = Prison::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == PORTALROOM_PIECE) box = PortalRoom::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    //WTF SPAGHETTI CODE
+    else if(componentType == RIGHTTURN_PIECE) box = LeftTurn::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == CHESTCORRIDOR_PIECE) box = ChestCorridor::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == ROOMCROSSING_PIECE) box = RoomCrossing::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    else if(componentType == LIBRARY_PIECE) box = Library::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    
+    if(box.start.y == -64) return false;
+    
+    return true;
 }
 
 bool getNextComponent(Data* data, int x1, int y1, int z1, int coordBaseMode, int componentType, int BFSlayer)
 {
-	//std::cout << "strongComponentType -- " << *strongComponentType << std::endl;
-	/* TODO CHECK IF THAT IS NECESSARY if (!canAddStructurePieces(*piecesWeight, totalWeight))
-	{
-		return NULL;
-	}
-	else
-	{*/
-		//if this is set, the game tries spawning that piece before any others.
-	if (data->priorityComponentType != 0)
-	{
-		bool var8 = getStrongholdComponentFromWeightedPiece(data, data->priorityComponentType, x1, y1, z1, coordBaseMode, BFSlayer);
-		//*strongComponentType = 0;
-		if (var8)
-			return true;
-	}
-	
-	int var13 = 0;
+    //std::cout << "strongComponentType -- " << *strongComponentType << std::endl;
+    /* TODO CHECK IF THAT IS NECESSARY if (!canAddStructurePieces(*piecesWeight, totalWeight))
+    {
+        return NULL;
+    }
+    else
+    {*/
+        //if this is set, the game tries spawning that piece before any others.
+    if (data->priorityComponentType != 0)
+    {
+        bool var8 = getStrongholdComponentFromWeightedPiece(data, data->priorityComponentType, x1, y1, z1, coordBaseMode, BFSlayer);
+        //*strongComponentType = 0;
+        if (var8)
+            return true;
+    }
+    
+    int var13 = 0;
 
     while (var13 < 5)
     {
-		++var13;
-		//std::cout << "totalWeight: " << data->totalWeight << std::endl;
-		int var9 = data->rng->nextInt(data->totalWeight);
-		//std::cout << "var9: " << var9 << std::endl;
-		for(int i = 0; i < 11; i++) {
-			if(data->weights[i].ignore) continue;
-			var9 -= data->weights[i].pieceWeight;
-			//std::cout << "--> var9: " << var9 << std::endl;
-			//std::cout << "pieceWeight: " << data->weights[i].componentType << std::endl;
-			if(var9 < 0) {
-				bool canSpawnPiece = data->weights[i].instancesLimit == 0 || data->weights[i].instancesSpawned < data->weights[i].instancesLimit;
-				if(data->weights[i].componentType == LIBRARY_PIECE && BFSlayer <= 4)
-					canSpawnPiece = false;
-				else if(data->weights[i].componentType == PORTALROOM_PIECE && BFSlayer <= 5)
-					canSpawnPiece = false;
-				if(!canSpawnPiece || i == data->toIgnore)
-					break;
-				
-				bool spawned = getStrongholdComponentFromWeightedPiece(data, data->weights[i].componentType, x1, y1, z1, coordBaseMode, BFSlayer);
-				
-				if(spawned) {
-					data->weights[i].instancesSpawned += 1;
-					
-					bool canSpawnPiece = data->weights[i].instancesLimit == 0 || data->weights[i].instancesSpawned < data->weights[i].instancesLimit;
-					if(data->weights[i].componentType == LIBRARY_PIECE && BFSlayer <= 4)
-						canSpawnPiece = false;
-					else if(data->weights[i].componentType == PORTALROOM_PIECE && BFSlayer <= 5)
-					canSpawnPiece = false;
-					if(!canSpawnPiece) {
-						data->totalWeight -= data->weights[i].pieceWeight;
-						data->weights[i].ignore = true;
-					}
-				
-					data->toIgnore = i;
-					//std::cout << "Added component type " << data->weights[i].componentType << std::endl;
-					return true;
-				}
-				else {
-					//std::cout << "Could not add component type " << data->weights[i].componentType << std::endl;
-				}
-			}
-		}
-	}
-	
-	BoundingBox box = Corridor::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
-	if(box.start.y != -64)
-		return true;
-	
-	return false;
+        ++var13;
+        //std::cout << "totalWeight: " << data->totalWeight << std::endl;
+        int var9 = data->rng->nextInt(data->totalWeight);
+        //std::cout << "var9: " << var9 << std::endl;
+        for(int i = 0; i < 11; i++) {
+            if(data->weights[i].ignore) continue;
+            var9 -= data->weights[i].pieceWeight;
+            //std::cout << "--> var9: " << var9 << std::endl;
+            //std::cout << "pieceWeight: " << data->weights[i].componentType << std::endl;
+            if(var9 < 0) {
+                bool canSpawnPiece = data->weights[i].instancesLimit == 0 || data->weights[i].instancesSpawned < data->weights[i].instancesLimit;
+                if(data->weights[i].componentType == LIBRARY_PIECE && BFSlayer <= 4)
+                    canSpawnPiece = false;
+                else if(data->weights[i].componentType == PORTALROOM_PIECE && BFSlayer <= 5)
+                    canSpawnPiece = false;
+                if(!canSpawnPiece || i == data->toIgnore)
+                    break;
+                
+                bool spawned = getStrongholdComponentFromWeightedPiece(data, data->weights[i].componentType, x1, y1, z1, coordBaseMode, BFSlayer);
+                
+                if(spawned) {
+                    data->weights[i].instancesSpawned += 1;
+                    
+                    bool canSpawnPiece = data->weights[i].instancesLimit == 0 || data->weights[i].instancesSpawned < data->weights[i].instancesLimit;
+                    if(data->weights[i].componentType == LIBRARY_PIECE && BFSlayer <= 4)
+                        canSpawnPiece = false;
+                    else if(data->weights[i].componentType == PORTALROOM_PIECE && BFSlayer <= 5)
+                    canSpawnPiece = false;
+                    if(!canSpawnPiece) {
+                        data->totalWeight -= data->weights[i].pieceWeight;
+                        data->weights[i].ignore = true;
+                    }
+                
+                    data->toIgnore = i;
+                    //std::cout << "Added component type " << data->weights[i].componentType << std::endl;
+                    return true;
+                }
+                else {
+                    //std::cout << "Could not add component type " << data->weights[i].componentType << std::endl;
+                }
+            }
+        }
+    }
+    
+    BoundingBox box = Corridor::GeneratePiece(data, x1, y1, z1, coordBaseMode, BFSlayer);
+    if(box.start.y != -64)
+        return true;
+    
+    return false;
 }
 
 bool Stronghold::getNextValidComponent(Data* data, int x1, int y1, int z1, int coordBaseMode, int componentType, int BFSlayer) {
-	if(data->portalFound) return false;
-	
-	//std::cout << "nextValidComponent - " << x1 << " " << y1 << " " << z1 << std::endl;
-	if (BFSlayer > 50)
-	{
-		return false;
-	}
+    if(data->portalFound) return false;
+    
+    //std::cout << "nextValidComponent - " << x1 << " " << y1 << " " << z1 << std::endl;
+    if (BFSlayer > 50)
+    {
+        return false;
+    }
 
-	BoundingBox startPieceBox = data->pieces[0].box;
-	//std::cout << startPiece->componentType << std::endl;
-	if (std::abs(x1 - startPieceBox.start.x) <= 112 && std::abs(z1 - startPieceBox.start.z) <= 112)
-	{
-		//if(*strongComponentType == 12) return NULL;
+    BoundingBox startPieceBox = data->pieces[0].box;
+    //std::cout << startPiece->componentType << std::endl;
+    if (std::abs(x1 - startPieceBox.start.x) <= 112 && std::abs(z1 - startPieceBox.start.z) <= 112)
+    {
+        //if(*strongComponentType == 12) return NULL;
 
-		bool var8 = getNextComponent(data, x1, y1, z1, coordBaseMode, componentType, BFSlayer + 1);
+        bool var8 = getNextComponent(data, x1, y1, z1, coordBaseMode, componentType, BFSlayer + 1);
 
-		/*if (var8 != NULL && var8->componentType != 12)
-		{
-			pieces->push_back(var8);
-			pieces_pending->push_back(var8);
-			//TODO p_75196_0_.field_75026_c.add(var8);
-		}
-		else if(var8 != NULL && var8->componentType == 12) {
-			*strongComponentType = 12;
+        /*if (var8 != NULL && var8->componentType != 12)
+        {
+            pieces->push_back(var8);
+            pieces_pending->push_back(var8);
+            //TODO p_75196_0_.field_75026_c.add(var8);
+        }
+        else if(var8 != NULL && var8->componentType == 12) {
+            *strongComponentType = 12;
 
-			pieces->push_back(var8);
-		}*/
-		//std::cout << "I'm here." << std::endl;
-		return true;
-	}
-	return false;
+            pieces->push_back(var8);
+        }*/
+        //std::cout << "I'm here." << std::endl;
+        return true;
+    }
+    return false;
 }

--- a/Pieces/Stronghold.h
+++ b/Pieces/Stronghold.h
@@ -5,6 +5,6 @@
 
 class Stronghold {
 public:
-	static bool getNextValidComponent(Data* data, int x1, int y1, int z1, int coordBaseMode, int componentType, int BFSlayer);
+    static bool getNextValidComponent(Data* data, int x1, int y1, int z1, int coordBaseMode, int componentType, int BFSlayer);
 };
 #endif

--- a/Pieces/StrongholdPiece.cpp
+++ b/Pieces/StrongholdPiece.cpp
@@ -3,82 +3,82 @@
  #include <iostream>
  
  BoundingBox StrongholdPiece::findIntersecting(Data* data, BoundingBox box) {
-	 BoundingBox ret;
-	 ret.start.x = -133769;
-	 
-	 //std::cout << "Searching for box " << box.getStr() << std::endl;
-	 for(int i = 0; i < data->pieceCnt; i++) {
-		 //std::cout << data->pieces[i].box.getStr() << std::endl;
-		 if(data->pieces[i].box.intersectsWith(&box)) return data->pieces[i].box;
-	 }
-	 return ret;
+     BoundingBox ret;
+     ret.start.x = -133769;
+     
+     //std::cout << "Searching for box " << box.getStr() << std::endl;
+     for(int i = 0; i < data->pieceCnt; i++) {
+         //std::cout << data->pieces[i].box.getStr() << std::endl;
+         if(data->pieces[i].box.intersectsWith(&box)) return data->pieces[i].box;
+     }
+     return ret;
  }
 
  bool StrongholdPiece::getNextComponentNormal(Data* data, PieceInfo thisPiece, int offset1, int offset2)
  {
-	 //std::cout << "called from " << thisPiece.componentType << std::endl;
-	switch (thisPiece.coordBaseMode)
-	{
-	case 0:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset1, thisPiece.box.start.y + offset2, thisPiece.box.end.z + 1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
+     //std::cout << "called from " << thisPiece.componentType << std::endl;
+    switch (thisPiece.coordBaseMode)
+    {
+    case 0:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset1, thisPiece.box.start.y + offset2, thisPiece.box.end.z + 1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 1:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset2, thisPiece.box.start.z + offset1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
+    case 1:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset2, thisPiece.box.start.z + offset1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 2:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset1, thisPiece.box.start.y + offset2, thisPiece.box.start.z - 1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
+    case 2:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset1, thisPiece.box.start.y + offset2, thisPiece.box.start.z - 1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 3:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset2, thisPiece.box.start.z + offset1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
+    case 3:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset2, thisPiece.box.start.z + offset1, thisPiece.coordBaseMode, thisPiece.componentType, thisPiece.BFSlayer);
 
-	default:
-		return false;
-	}
+    default:
+        return false;
+    }
 }
 
 bool StrongholdPiece::getNextComponentX(Data* data, PieceInfo thisPiece, int offset1, int offset2)
  {
-	//std::cout << "componentx coordBaseMode: " << thisPiece.coordBaseMode << std::endl;
-	switch (thisPiece.coordBaseMode)
-	{
-	case 0:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 1, thisPiece.componentType, thisPiece.BFSlayer);
+    //std::cout << "componentx coordBaseMode: " << thisPiece.coordBaseMode << std::endl;
+    switch (thisPiece.coordBaseMode)
+    {
+    case 0:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 1, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 1:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.start.z - 1, 2, thisPiece.componentType, thisPiece.BFSlayer);
+    case 1:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.start.z - 1, 2, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 2:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 1, thisPiece.componentType, thisPiece.BFSlayer);
+    case 2:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x - 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 1, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 3:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.start.z - 1, 2, thisPiece.componentType, thisPiece.BFSlayer);
-	
-	default:
-		return false;
-	}
+    case 3:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.start.z - 1, 2, thisPiece.componentType, thisPiece.BFSlayer);
+    
+    default:
+        return false;
+    }
 }
 
 bool StrongholdPiece::getNextComponentZ(Data* data, PieceInfo thisPiece, int offset1, int offset2)
  {
-	//std::cout << "componentz coordBaseMode: " << thisPiece.coordBaseMode << std::endl;
-	switch (thisPiece.coordBaseMode)
-	{
-	case 0:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 3, thisPiece.componentType, thisPiece.BFSlayer);
+    //std::cout << "componentz coordBaseMode: " << thisPiece.coordBaseMode << std::endl;
+    switch (thisPiece.coordBaseMode)
+    {
+    case 0:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 3, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 1:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.end.z + 1, 0, thisPiece.componentType, thisPiece.BFSlayer);
+    case 1:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.end.z + 1, 0, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 2:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 3, thisPiece.componentType, thisPiece.BFSlayer);
+    case 2:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.end.x + 1, thisPiece.box.start.y + offset1, thisPiece.box.start.z + offset2, 3, thisPiece.componentType, thisPiece.BFSlayer);
 
-	case 3:
-		return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.end.z + 1, 0, thisPiece.componentType, thisPiece.BFSlayer);
-	//return Stronghold::getNextValidComponent(pieces, pieces_pending, rng, this->box->start.x + offset2, this->box->start.y + offset1, this->box->end.z + 1, 0, this.getComponentType());
+    case 3:
+        return Stronghold::getNextValidComponent(data, thisPiece.box.start.x + offset2, thisPiece.box.start.y + offset1, thisPiece.box.end.z + 1, 0, thisPiece.componentType, thisPiece.BFSlayer);
+    //return Stronghold::getNextValidComponent(pieces, pieces_pending, rng, this->box->start.x + offset2, this->box->start.y + offset1, this->box->end.z + 1, 0, this.getComponentType());
 
-	default:
-		return NULL;
-	}
+    default:
+        return NULL;
+    }
 }
 
 /*StrongholdPiece* StrongholdPiece::getNextComponentZ(std::vector<StrongholdPiece *>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int offset1, int offset2, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight)

--- a/Pieces/StrongholdPiece.h
+++ b/Pieces/StrongholdPiece.h
@@ -9,18 +9,18 @@
 
 class StrongholdPiece {
 public:
-	static bool getNextComponentNormal(Data* data, PieceInfo thisPiece, int offset1, int offset2);
-	static bool getNextComponentZ(Data* data, PieceInfo thisPiece, int offset1, int offset2);
-	static bool getNextComponentX(Data* data, PieceInfo thisPiece, int offset1, int offset2);
-	static BoundingBox findIntersecting(Data* data, BoundingBox box);
-	//static StrongholdPiece* findIntersecting(std::vector<StrongholdPiece *> pieces, BoundingBox* box);
+    static bool getNextComponentNormal(Data* data, PieceInfo thisPiece, int offset1, int offset2);
+    static bool getNextComponentZ(Data* data, PieceInfo thisPiece, int offset1, int offset2);
+    static bool getNextComponentX(Data* data, PieceInfo thisPiece, int offset1, int offset2);
+    static BoundingBox findIntersecting(Data* data, BoundingBox box);
+    //static StrongholdPiece* findIntersecting(std::vector<StrongholdPiece *> pieces, BoundingBox* box);
 
-	/*StrongholdPiece* getNextComponentNormal(std::vector<StrongholdPiece*>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int offsetX, int offsetY, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
+    /*StrongholdPiece* getNextComponentNormal(std::vector<StrongholdPiece*>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int offsetX, int offsetY, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
 
-	StrongholdPiece* getNextComponentZ(std::vector<StrongholdPiece *>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rnd, int offset1, int offset2, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
+    StrongholdPiece* getNextComponentZ(std::vector<StrongholdPiece *>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rnd, int offset1, int offset2, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
 
-	StrongholdPiece* getNextComponentX(std::vector<StrongholdPiece *>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int offset1, int offset2, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
+    StrongholdPiece* getNextComponentX(std::vector<StrongholdPiece *>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int offset1, int offset2, int BFSlayer, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight);
 
-	virtual void buildComponent(std::vector<StrongholdPiece*>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight) {}*/
+    virtual void buildComponent(std::vector<StrongholdPiece*>* pieces, std::vector<StrongholdPiece*>* pieces_pending, JavaRnd* rng, int* strongComponentType, int* totalWeight, std::vector<PieceWeight*>* piecesWeight, PieceWeight** strongholdPieceWeight) {}*/
 };
 #endif

--- a/Utils/BoundingBox.h
+++ b/Utils/BoundingBox.h
@@ -6,56 +6,56 @@
 #include <climits>
 class BoundingBox {
 public:
-	Position start;
-	Position end;
+    Position start;
+    Position end;
 
-	static BoundingBox getNewBoundingBox() {
-		return getBoundingBox(INT_MAX, INT_MAX, INT_MAX, INT_MIN, INT_MIN, INT_MIN);
-	}
-	
-	static BoundingBox getBoundingBox(int minx, int miny, int minz, int maxx, int maxy, int maxz) {
-		BoundingBox box;
-		box.start.x = minx;
-		box.start.y = miny;
-		box.start.z = minz;
-		box.end.x = maxx;
-		box.end.y = maxy;
-		box.end.z = maxz;
-		return box;
-	}
-	
-	std::string getStr() {
-		return std::string("(") + std::to_string(start.x) + std::string(",") + std::to_string(start.y) + std::string(",") + std::to_string(start.z) + std::string(")(") + std::to_string(end.x) + std::string(",") + std::to_string(end.y) + std::string(",") + std::to_string(end.z) + std::string(")");
-	}
-
-	bool intersectsWith(BoundingBox* box)
-	{
-		return this->end.x >= box->start.x && this->start.x <= box->end.x && this->end.z >= box->start.z && this->start.z <= box->end.z && this->end.y >= box->start.y && this->start.y <= box->end.y;
-	}
-
-	void setStart(int x, int y, int z) {
-		this->start.x = x;
-		this->start.y = y;
-		this->start.z = z;
-	}
-	
-	void setEnd(int x, int y, int z) {
-		this->end.x = x;
-		this->end.y = y;
-		this->end.z = z;
-	}
-	
-	void setAll(int x1, int y1, int z1, int x2, int y2, int z2) {
-		setStart(x1, y1, z1);
-		setEnd(x2, y2, z2);
-	}
-	
-	int getYSize()
-    {
-       	return this->end.y - this->start.y + 1;
+    static BoundingBox getNewBoundingBox() {
+        return getBoundingBox(INT_MAX, INT_MAX, INT_MAX, INT_MIN, INT_MIN, INT_MIN);
     }
-	
-	void expandTo(BoundingBox box)
+    
+    static BoundingBox getBoundingBox(int minx, int miny, int minz, int maxx, int maxy, int maxz) {
+        BoundingBox box;
+        box.start.x = minx;
+        box.start.y = miny;
+        box.start.z = minz;
+        box.end.x = maxx;
+        box.end.y = maxy;
+        box.end.z = maxz;
+        return box;
+    }
+    
+    std::string getStr() {
+        return std::string("(") + std::to_string(start.x) + std::string(",") + std::to_string(start.y) + std::string(",") + std::to_string(start.z) + std::string(")(") + std::to_string(end.x) + std::string(",") + std::to_string(end.y) + std::string(",") + std::to_string(end.z) + std::string(")");
+    }
+
+    bool intersectsWith(BoundingBox* box)
+    {
+        return this->end.x >= box->start.x && this->start.x <= box->end.x && this->end.z >= box->start.z && this->start.z <= box->end.z && this->end.y >= box->start.y && this->start.y <= box->end.y;
+    }
+
+    void setStart(int x, int y, int z) {
+        this->start.x = x;
+        this->start.y = y;
+        this->start.z = z;
+    }
+    
+    void setEnd(int x, int y, int z) {
+        this->end.x = x;
+        this->end.y = y;
+        this->end.z = z;
+    }
+    
+    void setAll(int x1, int y1, int z1, int x2, int y2, int z2) {
+        setStart(x1, y1, z1);
+        setEnd(x2, y2, z2);
+    }
+    
+    int getYSize()
+    {
+           return this->end.y - this->start.y + 1;
+    }
+    
+    void expandTo(BoundingBox box)
     {
         this->start.x = std::min(this->start.x, box.start.x);
         this->start.y = std::min(this->start.y, box.start.y);
@@ -64,32 +64,32 @@ public:
         this->end.y = std::max(this->end.y, box.end.y);
         this->end.z = std::max(this->end.z, box.end.z);
     }
-	
-	static BoundingBox getComponentToAddBoundingBox(int p_78889_0_, int p_78889_1_, int p_78889_2_, int p_78889_3_, int p_78889_4_, int p_78889_5_, int p_78889_6_, int p_78889_7_, int p_78889_8_, int p_78889_9_)
-	{
-		BoundingBox ret;
-		ret.setAll(-133769, -2, -1, 1, 2, 3);
-		switch (p_78889_9_)
-		{
-			case 0:
-				ret.setAll(p_78889_0_ + p_78889_3_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_5_, p_78889_0_ + p_78889_6_ - 1 + p_78889_3_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_8_ - 1 + p_78889_5_);
-				return ret;
+    
+    static BoundingBox getComponentToAddBoundingBox(int p_78889_0_, int p_78889_1_, int p_78889_2_, int p_78889_3_, int p_78889_4_, int p_78889_5_, int p_78889_6_, int p_78889_7_, int p_78889_8_, int p_78889_9_)
+    {
+        BoundingBox ret;
+        ret.setAll(-133769, -2, -1, 1, 2, 3);
+        switch (p_78889_9_)
+        {
+            case 0:
+                ret.setAll(p_78889_0_ + p_78889_3_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_5_, p_78889_0_ + p_78889_6_ - 1 + p_78889_3_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_8_ - 1 + p_78889_5_);
+                return ret;
 
-			case 1:
-				ret.setAll(p_78889_0_ - p_78889_8_ + 1 + p_78889_5_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_3_, p_78889_0_ + p_78889_5_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_6_ - 1 + p_78889_3_);
-				return ret;
+            case 1:
+                ret.setAll(p_78889_0_ - p_78889_8_ + 1 + p_78889_5_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_3_, p_78889_0_ + p_78889_5_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_6_ - 1 + p_78889_3_);
+                return ret;
 
-			case 2:
-				ret.setAll(p_78889_0_ + p_78889_3_, p_78889_1_ + p_78889_4_, p_78889_2_ - p_78889_8_ + 1 + p_78889_5_, p_78889_0_ + p_78889_6_ - 1 + p_78889_3_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_5_);
-				return ret;
+            case 2:
+                ret.setAll(p_78889_0_ + p_78889_3_, p_78889_1_ + p_78889_4_, p_78889_2_ - p_78889_8_ + 1 + p_78889_5_, p_78889_0_ + p_78889_6_ - 1 + p_78889_3_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_5_);
+                return ret;
 
-			case 3:
-				ret.setAll(p_78889_0_ + p_78889_5_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_3_, p_78889_0_ + p_78889_8_ - 1 + p_78889_5_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_6_ - 1 + p_78889_3_);
-				return ret;
+            case 3:
+                ret.setAll(p_78889_0_ + p_78889_5_, p_78889_1_ + p_78889_4_, p_78889_2_ + p_78889_3_, p_78889_0_ + p_78889_8_ - 1 + p_78889_5_, p_78889_1_ + p_78889_7_ - 1 + p_78889_4_, p_78889_2_ + p_78889_6_ - 1 + p_78889_3_);
+                return ret;
 
-			default:
-				return ret;
-		}
-	}
+            default:
+                return ret;
+        }
+    }
 };
 #endif

--- a/Utils/Data.h
+++ b/Utils/Data.h
@@ -9,139 +9,139 @@
 
 #define PIECE_START 0
 
-#define STAIRS2_PIECE 		 0
-#define CROSSING_PIECE 		 1
-#define LEFTTURN_PIECE 		 2
-#define STRAIGHT_PIECE 		 3
+#define STAIRS2_PIECE          0
+#define CROSSING_PIECE          1
+#define LEFTTURN_PIECE          2
+#define STRAIGHT_PIECE          3
 #define STAIRSSTRAIGHT_PIECE 4
 #define STAIRS_PIECE         5
 #define CORRIDOR_PIECE       6
 #define PRISON_PIECE         7
-#define RIGHTTURN_PIECE 	 8
-#define ROOMCROSSING_PIECE 	 9
+#define RIGHTTURN_PIECE      8
+#define ROOMCROSSING_PIECE      9
 #define CHESTCORRIDOR_PIECE 10
-#define LIBRARY_PIECE 	    11
-#define PORTALROOM_PIECE 	12
+#define LIBRARY_PIECE         11
+#define PORTALROOM_PIECE     12
 
 class PieceInfo {
 public:
-	BoundingBox box;
-	int coordBaseMode;
-	int componentType;
-	int BFSlayer;
-	int pieceID;
-	bool field1;
-	bool field2;
-	bool field3;
-	bool field4;
+    BoundingBox box;
+    int coordBaseMode;
+    int componentType;
+    int BFSlayer;
+    int pieceID;
+    bool field1;
+    bool field2;
+    bool field3;
+    bool field4;
 };
 
 class PieceWeight {
 public:
-	int instancesLimit;
-	int instancesSpawned;
-	int componentType;
-	int pieceWeight;
-	bool ignore = false;
-	
-	void setData(int componentType, int pieceWeight, int instancesLimit) {
-		this->componentType = componentType;
-		this->pieceWeight = pieceWeight;
-		this->instancesLimit = instancesLimit;
-		this->instancesSpawned = 0;
-		this->ignore = false;
-	}
+    int instancesLimit;
+    int instancesSpawned;
+    int componentType;
+    int pieceWeight;
+    bool ignore = false;
+    
+    void setData(int componentType, int pieceWeight, int instancesLimit) {
+        this->componentType = componentType;
+        this->pieceWeight = pieceWeight;
+        this->instancesLimit = instancesLimit;
+        this->instancesSpawned = 0;
+        this->ignore = false;
+    }
 };
 
 class Data {
 public:
-	int64_t seed;
-	int StartChunkX;
-	int StartChunkZ;
-	JavaRnd* rng;
-	
-	PieceInfo pieces[1000];
-	std::vector<PieceInfo> pieces_pending;
-	//PieceInfo pieces_pending[1000];
-	PieceWeight weights[11];
-	
-	bool portalFound = false;
-	int totalWeight = 145;
-	int pieceCnt = 0;
-	int pendingCnt = 0;
-	int priorityComponentType = 0;
-	int toIgnore = -1;
-	int toProcess = 0;
-	
-	Data() {
-		rng = new JavaRnd(0);
-		pieces_pending.reserve(1000);
-	}
-	
-	void initWeights() {
-		weights[ 0].setData( 3, 40, 0); //straight
-		weights[ 1].setData( 7,  5, 5); //prison
-		weights[ 2].setData( 2, 20, 0); //left_turn
-		weights[ 3].setData( 8, 20, 0); //right_turn
-		weights[ 4].setData( 9, 10, 6); //room_crossing
-		weights[ 5].setData( 4,  5, 5); //stairs_straight
-		weights[ 6].setData( 5,  5, 5); //stairs
-		weights[ 7].setData( 1,  5, 4); //crossing
-		weights[ 8].setData(10,  5, 4); //chest_corridor
-		weights[ 9].setData(11, 10, 2); //library
-		weights[10].setData(12, 20, 1); //portalroom
-	}
-	
-	void addPiece(int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
-		if(this->portalFound) return;
-		//std::cout << "spawned. " << componentType << std::endl;
-		setPiece(pieceCnt++, componentType, coordBaseMode, BFSlayer, box);
-	}
-	
-	void addPiecePending(int componentType, int coordBaseMode, int BFSlayer, BoundingBox box, bool field1 = false, bool field2 = false, bool field3 = false, bool field4 = false) {
-		if(this->portalFound) return;
-		
-		PieceInfo pieceInfo;
-		
-		pieceInfo.componentType = componentType;
-		pieceInfo.coordBaseMode = coordBaseMode;
-		pieceInfo.BFSlayer = BFSlayer;
-		pieceInfo.box = box;
-		
-		pieceInfo.field1 = field1;
-		pieceInfo.field2 = field2;
-		pieceInfo.field3 = field3;
-		pieceInfo.field4 = field4;
-		
-		pieces_pending.push_back(pieceInfo);
-		//setPiecePending(pendingCnt++, componentType, coordBaseMode, BFSlayer, box);
-	}
-	
-	void setPiece(int pieceID, int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
-		pieces[pieceID].componentType = componentType;
-		pieces[pieceID].coordBaseMode = coordBaseMode;
-		pieces[pieceID].BFSlayer = BFSlayer;
-		pieces[pieceID].box = box;
-	}
-	
-	void setPiecePending(int pieceID, int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
-		
-	}
-	
-	void addBox(BoundingBox box) {
-		pieces[pieceCnt++].box = box;
-	}
-	
-	void reset() {
-		initWeights();
-		totalWeight = 145;
-		pieceCnt = 0;
-		toIgnore = -1;
-		priorityComponentType = 0;
-		pendingCnt = 0;
-		pieces_pending.clear();
-		portalFound = false;
-	}
+    int64_t seed;
+    int StartChunkX;
+    int StartChunkZ;
+    JavaRnd* rng;
+    
+    PieceInfo pieces[1000];
+    std::vector<PieceInfo> pieces_pending;
+    //PieceInfo pieces_pending[1000];
+    PieceWeight weights[11];
+    
+    bool portalFound = false;
+    int totalWeight = 145;
+    int pieceCnt = 0;
+    int pendingCnt = 0;
+    int priorityComponentType = 0;
+    int toIgnore = -1;
+    int toProcess = 0;
+    
+    Data() {
+        rng = new JavaRnd(0);
+        pieces_pending.reserve(1000);
+    }
+    
+    void initWeights() {
+        weights[ 0].setData( 3, 40, 0); //straight
+        weights[ 1].setData( 7,  5, 5); //prison
+        weights[ 2].setData( 2, 20, 0); //left_turn
+        weights[ 3].setData( 8, 20, 0); //right_turn
+        weights[ 4].setData( 9, 10, 6); //room_crossing
+        weights[ 5].setData( 4,  5, 5); //stairs_straight
+        weights[ 6].setData( 5,  5, 5); //stairs
+        weights[ 7].setData( 1,  5, 4); //crossing
+        weights[ 8].setData(10,  5, 4); //chest_corridor
+        weights[ 9].setData(11, 10, 2); //library
+        weights[10].setData(12, 20, 1); //portalroom
+    }
+    
+    void addPiece(int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
+        if(this->portalFound) return;
+        //std::cout << "spawned. " << componentType << std::endl;
+        setPiece(pieceCnt++, componentType, coordBaseMode, BFSlayer, box);
+    }
+    
+    void addPiecePending(int componentType, int coordBaseMode, int BFSlayer, BoundingBox box, bool field1 = false, bool field2 = false, bool field3 = false, bool field4 = false) {
+        if(this->portalFound) return;
+        
+        PieceInfo pieceInfo;
+        
+        pieceInfo.componentType = componentType;
+        pieceInfo.coordBaseMode = coordBaseMode;
+        pieceInfo.BFSlayer = BFSlayer;
+        pieceInfo.box = box;
+        
+        pieceInfo.field1 = field1;
+        pieceInfo.field2 = field2;
+        pieceInfo.field3 = field3;
+        pieceInfo.field4 = field4;
+        
+        pieces_pending.push_back(pieceInfo);
+        //setPiecePending(pendingCnt++, componentType, coordBaseMode, BFSlayer, box);
+    }
+    
+    void setPiece(int pieceID, int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
+        pieces[pieceID].componentType = componentType;
+        pieces[pieceID].coordBaseMode = coordBaseMode;
+        pieces[pieceID].BFSlayer = BFSlayer;
+        pieces[pieceID].box = box;
+    }
+    
+    void setPiecePending(int pieceID, int componentType, int coordBaseMode, int BFSlayer, BoundingBox box) {
+        
+    }
+    
+    void addBox(BoundingBox box) {
+        pieces[pieceCnt++].box = box;
+    }
+    
+    void reset() {
+        initWeights();
+        totalWeight = 145;
+        pieceCnt = 0;
+        toIgnore = -1;
+        priorityComponentType = 0;
+        pendingCnt = 0;
+        pieces_pending.clear();
+        portalFound = false;
+    }
 };
 
 #endif

--- a/Utils/Pos.h
+++ b/Utils/Pos.h
@@ -3,8 +3,8 @@
 
 class Position {
 public:
-	int x = 0;
-	int y = 0;
-	int z = 0;
+    int x = 0;
+    int y = 0;
+    int z = 0;
 };
 #endif

--- a/Utils/Random.h
+++ b/Utils/Random.h
@@ -6,55 +6,55 @@
 class JavaRnd
 {
 private:
-	uint64_t seed;
+    uint64_t seed;
 
 public:
-	JavaRnd(int64_t seed) {
-	  setSeed(seed);
-	}
+    JavaRnd(int64_t seed) {
+      setSeed(seed);
+    }
 
   inline void setSeed(int64_t seed) {
-	this->seed = (uint64_t)((uint64_t)seed ^ 0x5deece66du) & ((1LLu << 48) - 1);
+    this->seed = (uint64_t)((uint64_t)seed ^ 0x5deece66du) & ((1LLu << 48) - 1);
   }
 
-	inline int nextInt(int n)
-	{
-		//if (n <= 0) throw new ArgumentException("n must be positive");
+    inline int nextInt(int n)
+    {
+        //if (n <= 0) throw new ArgumentException("n must be positive");
 
-		if ((n & -n) == n)  // i.e., n is a power of 2
-			return (int)((n * (int64_t)Next(31)) >> 31u);
+        if ((n & -n) == n)  // i.e., n is a power of 2
+            return (int)((n * (int64_t)Next(31)) >> 31u);
 
-		long bits, val;
-		do
-		{
-			bits = Next(31);
-			val = bits % (int32_t)n;
-		}
-		while (bits - val + (n - 1) < 0);
+        long bits, val;
+        do
+        {
+            bits = Next(31);
+            val = bits % (int32_t)n;
+        }
+        while (bits - val + (n - 1) < 0);
 
-		return (int)val;
-	}
+        return (int)val;
+    }
 
-	inline bool nextBoolean() {
-		return Next(1) != 0;
-	}
+    inline bool nextBoolean() {
+        return Next(1) != 0;
+    }
 
-	inline double NextDouble()
-	{
-		return (((int64_t)Next(26) << 27u) + Next(27))
-		  / (double)(1LLu << 53u);
-	}
+    inline double NextDouble()
+    {
+        return (((int64_t)Next(26) << 27u) + Next(27))
+          / (double)(1LLu << 53u);
+    }
 
-	inline int32_t Next(int bits)
-	{
-		seed = (seed * 0x5deece66du + 0xBu) & ((1LLu << 48u) - 1);
+    inline int32_t Next(int bits)
+    {
+        seed = (seed * 0x5deece66du + 0xBu) & ((1LLu << 48u) - 1);
 
-		return (int32_t)(seed >> (48u - bits));
-	}
-	
-	inline int64_t nextLong()
-	{
-		return ((int64_t) Next(32) << 32) + Next(32);
-	}
+        return (int32_t)(seed >> (48u - bits));
+    }
+    
+    inline int64_t nextLong()
+    {
+        return ((int64_t) Next(32) << 32) + Next(32);
+    }
 };
 #endif

--- a/filter9000-boinc.cpp
+++ b/filter9000-boinc.cpp
@@ -33,90 +33,90 @@
 
 
 void setInitialRng(Data* data) {
-	int64_t worldSeed = data->seed;
-	int chunkX = data->StartChunkX;
-	int chunkZ = data->StartChunkZ;
+    int64_t worldSeed = data->seed;
+    int chunkX = data->StartChunkX;
+    int chunkZ = data->StartChunkZ;
 
-	data->rng->setSeed(worldSeed);
+    data->rng->setSeed(worldSeed);
 
-	int64_t var7 = data->rng->nextLong();
-	int64_t var9 = data->rng->nextLong();
-	int64_t var13 = (int64_t)chunkX * var7;
-	int64_t var15 = (int64_t)chunkZ * var9;
-	int64_t internalSeed = var13 ^ var15 ^ worldSeed;
+    int64_t var7 = data->rng->nextLong();
+    int64_t var9 = data->rng->nextLong();
+    int64_t var13 = (int64_t)chunkX * var7;
+    int64_t var15 = (int64_t)chunkZ * var9;
+    int64_t internalSeed = var13 ^ var15 ^ worldSeed;
 
-	data->rng->setSeed(internalSeed);
-	
-	data->rng->Next(32);
+    data->rng->setSeed(internalSeed);
+    
+    data->rng->Next(32);
 }
 
-void setFirstPiece(Data* data) {	
-	Stairs2::GeneratePiece(data);
-	data->priorityComponentType = 1;
-	Stairs2::BuildComponent(data);
-	data->priorityComponentType = 0;
+void setFirstPiece(Data* data) {    
+    Stairs2::GeneratePiece(data);
+    data->priorityComponentType = 1;
+    Stairs2::BuildComponent(data);
+    data->priorityComponentType = 0;
 }
 
 void BuildComponent(Data* data, PieceInfo pieceInfo) {
-	int componentType = pieceInfo.componentType;
+    int componentType = pieceInfo.componentType;
 
-	if(componentType == CROSSING_PIECE) Crossing::BuildComponent(data, pieceInfo);
-	else if(componentType == LEFTTURN_PIECE) LeftTurn::BuildComponent(data, pieceInfo);
-	else if(componentType == STRAIGHT_PIECE) Straight::BuildComponent(data, pieceInfo);
-	else if(componentType == STAIRSSTRAIGHT_PIECE) StairsStraight::BuildComponent(data, pieceInfo);
-	else if(componentType == ROOMCROSSING_PIECE) RoomCrossing::BuildComponent(data, pieceInfo);
-	else if(componentType == PRISON_PIECE) Prison::BuildComponent(data, pieceInfo);
-	else if(componentType == STAIRS_PIECE) Stairs::BuildComponent(data, pieceInfo);
-	else if(componentType == RIGHTTURN_PIECE) LeftTurn::BuildComponent(data, pieceInfo);
-	else if(componentType == CHESTCORRIDOR_PIECE) ChestCorridor::BuildComponent(data, pieceInfo);
-	else if(componentType == CORRIDOR_PIECE || componentType == LIBRARY_PIECE) {}
-	else
-		std::cout << "COULD NOT BUILD COMPONENT TYPE " << componentType << std::endl;
+    if(componentType == CROSSING_PIECE) Crossing::BuildComponent(data, pieceInfo);
+    else if(componentType == LEFTTURN_PIECE) LeftTurn::BuildComponent(data, pieceInfo);
+    else if(componentType == STRAIGHT_PIECE) Straight::BuildComponent(data, pieceInfo);
+    else if(componentType == STAIRSSTRAIGHT_PIECE) StairsStraight::BuildComponent(data, pieceInfo);
+    else if(componentType == ROOMCROSSING_PIECE) RoomCrossing::BuildComponent(data, pieceInfo);
+    else if(componentType == PRISON_PIECE) Prison::BuildComponent(data, pieceInfo);
+    else if(componentType == STAIRS_PIECE) Stairs::BuildComponent(data, pieceInfo);
+    else if(componentType == RIGHTTURN_PIECE) LeftTurn::BuildComponent(data, pieceInfo);
+    else if(componentType == CHESTCORRIDOR_PIECE) ChestCorridor::BuildComponent(data, pieceInfo);
+    else if(componentType == CORRIDOR_PIECE || componentType == LIBRARY_PIECE) {}
+    else
+        std::cout << "COULD NOT BUILD COMPONENT TYPE " << componentType << std::endl;
 }
 
 
 void generateAllPieces(Data* threadData, int64_t seed, int startChunkX, int startChunkZ) {
-	threadData->reset();	
-	setFirstPiece(threadData);
+    threadData->reset();    
+    setFirstPiece(threadData);
 
-	while(threadData->pieces_pending.size() != 0) {
-		int randomPieceNumber = threadData->rng->nextInt(threadData->pieces_pending.size());
-		PieceInfo pieceChosen = threadData->pieces_pending.at(randomPieceNumber);
-		threadData->pieces_pending.erase(threadData->pieces_pending.begin() + randomPieceNumber);
+    while(threadData->pieces_pending.size() != 0) {
+        int randomPieceNumber = threadData->rng->nextInt(threadData->pieces_pending.size());
+        PieceInfo pieceChosen = threadData->pieces_pending.at(randomPieceNumber);
+        threadData->pieces_pending.erase(threadData->pieces_pending.begin() + randomPieceNumber);
 
-		BuildComponent(threadData, pieceChosen);
+        BuildComponent(threadData, pieceChosen);
 
-		if(threadData->portalFound)
-			break;
-	}
+        if(threadData->portalFound)
+            break;
+    }
 
-	
-	PieceInfo lastPiece = threadData->pieces[threadData->pieceCnt - 1];
-	if(lastPiece.componentType != PORTALROOM_PIECE) {
-		BoundingBox structureBox = BoundingBox::getNewBoundingBox();
-		for(int i = 0; i < threadData->pieceCnt; i++) {
-			structureBox.expandTo(threadData->pieces[i].box);
-		}
-		
-		int ySize = structureBox.getYSize() + 1;
-		if(ySize < 53)
-			threadData->rng->nextInt(53 - ySize);
-		
-		generateAllPieces(threadData, seed, startChunkX, startChunkZ);
-	}
+    
+    PieceInfo lastPiece = threadData->pieces[threadData->pieceCnt - 1];
+    if(lastPiece.componentType != PORTALROOM_PIECE) {
+        BoundingBox structureBox = BoundingBox::getNewBoundingBox();
+        for(int i = 0; i < threadData->pieceCnt; i++) {
+            structureBox.expandTo(threadData->pieces[i].box);
+        }
+        
+        int ySize = structureBox.getYSize() + 1;
+        if(ySize < 53)
+            threadData->rng->nextInt(53 - ySize);
+        
+        generateAllPieces(threadData, seed, startChunkX, startChunkZ);
+    }
 }
 
 PieceInfo getLastPiece(Data* threadData, int64_t seed, int startChunkX, int startChunkZ) {
-	generateAllPieces(threadData, seed, startChunkX, startChunkZ);
-	
-	return threadData->pieces[threadData->pieceCnt - 1];
+    generateAllPieces(threadData, seed, startChunkX, startChunkZ);
+    
+    return threadData->pieces[threadData->pieceCnt - 1];
 }
 
 Position getCenterPos(BoundingBox box) {
-	Position ret;
-	ret.x = (box.end.x + box.start.x) / 2;
-	ret.z = (box.end.z + box.start.z) / 2;
-	return ret;
+    Position ret;
+    ret.x = (box.end.x + box.start.x) / 2;
+    ret.z = (box.end.z + box.start.z) / 2;
+    return ret;
 }
 
 
@@ -124,77 +124,77 @@ FILE *fp;
 int outCount = 0;
 void getStrongholdPositions(LayerStack* g, int64_t* worldSeed, int SH, Data* data, int* cache, BoundingBox* boxCache, int desiredX, int desiredZ)
 {
-	static const char* isStrongholdBiome = getValidStrongholdBiomes();
+    static const char* isStrongholdBiome = getValidStrongholdBiomes();
 
         int64_t copy = *worldSeed;
-	applySeed(g, *worldSeed);
+    applySeed(g, *worldSeed);
 
-	Layer *l = &g->layers[L_RIVER_MIX_4];
+    Layer *l = &g->layers[L_RIVER_MIX_4];
 
-	setSeed(worldSeed);
-	long double angle = nextDouble(worldSeed) * PI * 2.0;
-	int var6 = 1;
+    setSeed(worldSeed);
+    long double angle = nextDouble(worldSeed) * PI * 2.0;
+    int var6 = 1;
 
-	//SH here determines how many strongholds to generate
-	for (int var7 = 0; var7 < SH; ++var7)
-	{
-		long double distance = (1.25 * (double)var6 + nextDouble(worldSeed)) * 32.0 * (double)var6;
-		int x = (int)round(cos(angle) * distance);
-		int z = (int)round(sin(angle) * distance);
+    //SH here determines how many strongholds to generate
+    for (int var7 = 0; var7 < SH; ++var7)
+    {
+        long double distance = (1.25 * (double)var6 + nextDouble(worldSeed)) * 32.0 * (double)var6;
+        int x = (int)round(cos(angle) * distance);
+        int z = (int)round(sin(angle) * distance);
 
-		Pos biomePos = findBiomePosition(MC_1_7, l, cache, (x << 4) + 8, (z << 4) + 8, 112, isStrongholdBiome, worldSeed, NULL);
+        Pos biomePos = findBiomePosition(MC_1_7, l, cache, (x << 4) + 8, (z << 4) + 8, 112, isStrongholdBiome, worldSeed, NULL);
 
-		x = biomePos.x >> 4;
-		z = biomePos.z >> 4;
+        x = biomePos.x >> 4;
+        z = biomePos.z >> 4;
 
-		PieceInfo lastPiece = getLastPiece(data, copy, x, z);
-		if(lastPiece.componentType == PORTALROOM_PIECE) {
-			int pos1X, pos1Z, pos2X, pos2Z;
+        PieceInfo lastPiece = getLastPiece(data, copy, x, z);
+        if(lastPiece.componentType == PORTALROOM_PIECE) {
+            int pos1X, pos1Z, pos2X, pos2Z;
 
-			if(lastPiece.coordBaseMode == 0) {
-				pos1X = lastPiece.box.start.x + 3;
-				pos1Z = lastPiece.box.start.z + 12;
-				pos2X = lastPiece.box.start.x + 7;
-				pos2Z = lastPiece.box.start.z + 8;
-			}
+            if(lastPiece.coordBaseMode == 0) {
+                pos1X = lastPiece.box.start.x + 3;
+                pos1Z = lastPiece.box.start.z + 12;
+                pos2X = lastPiece.box.start.x + 7;
+                pos2Z = lastPiece.box.start.z + 8;
+            }
 
-			else if(lastPiece.coordBaseMode == 1) {
-				pos1X = lastPiece.box.start.x + 7;
-				pos1Z = lastPiece.box.start.z + 7;
-				pos2X = lastPiece.box.start.x + 3;
-				pos2Z = lastPiece.box.start.z + 3;
-			}
+            else if(lastPiece.coordBaseMode == 1) {
+                pos1X = lastPiece.box.start.x + 7;
+                pos1Z = lastPiece.box.start.z + 7;
+                pos2X = lastPiece.box.start.x + 3;
+                pos2Z = lastPiece.box.start.z + 3;
+            }
 
-			else if(lastPiece.coordBaseMode == 2) {
-				pos1X = lastPiece.box.start.x + 3;
-				pos1Z = lastPiece.box.start.z + 7;
-				pos2X = lastPiece.box.start.x + 7;
-				pos2Z = lastPiece.box.start.z + 3;
-			}
+            else if(lastPiece.coordBaseMode == 2) {
+                pos1X = lastPiece.box.start.x + 3;
+                pos1Z = lastPiece.box.start.z + 7;
+                pos2X = lastPiece.box.start.x + 7;
+                pos2Z = lastPiece.box.start.z + 3;
+            }
 
-			else if(lastPiece.coordBaseMode == 3) {
-				pos1X = lastPiece.box.start.x + 12;
-				pos1Z = lastPiece.box.start.z + 7;
-				pos2X = lastPiece.box.start.x + 8;
-				pos2Z = lastPiece.box.start.z + 3;
-			}
+            else if(lastPiece.coordBaseMode == 3) {
+                pos1X = lastPiece.box.start.x + 12;
+                pos1Z = lastPiece.box.start.z + 7;
+                pos2X = lastPiece.box.start.x + 8;
+                pos2Z = lastPiece.box.start.z + 3;
+            }
 
-			if((pos1X - 8) >> 4 == desiredX && (pos2X - 8) >> 4 == desiredX) {
-				if((pos1Z - 8) >> 4 == desiredZ && (pos2Z - 8) >> 4 == desiredZ) {
-					Position center = getCenterPos(lastPiece.box);
-					fprintf(fp, "%lld %d %d %d %d\n", copy, center.x >> 4, center.z >> 4, center.x, center.z);
-					outCount++;
-				}
-			}
+            if((pos1X - 8) >> 4 == desiredX && (pos2X - 8) >> 4 == desiredX) {
+                if((pos1Z - 8) >> 4 == desiredZ && (pos2Z - 8) >> 4 == desiredZ) {
+                    Position center = getCenterPos(lastPiece.box);
+                    fprintf(fp, "%lld %d %d %d %d\n", copy, center.x >> 4, center.z >> 4, center.x, center.z);
+                    outCount++;
+                }
+            }
 
-			/*if((lastPiece.box.start.x >> 4 == desiredX && lastPiece.box.start.z >> 4 == desiredZ) || (lastPiece.box.end.x >> 4 == desiredX && lastPiece.box.end.z >> 4 == desiredZ)) {
-				Position center = getCenterPos(lastPiece.box);
-				printf("%lld %d %d %d %d\n", copy, center.x >> 4, center.z >> 4, center.x, center.z);
-			}
-			/*std::cout << "Portal room for Stronghold " << var7 << " is at " << center.x << " " << center.z << ", and there are " << data->pieceCnt << " pieces that were generated before the portal room itself.\n\n" << std::endl;*/
-		}
-		angle += 2 * PI / 3.0;
-	}
+            /*if((lastPiece.box.start.x >> 4 == desiredX && lastPiece.box.start.z >> 4 == desiredZ) || (lastPiece.box.end.x >> 4 == desiredX && lastPiece.box.end.z >> 4 == desiredZ)) {
+                Position center = getCenterPos(lastPiece.box);
+                printf("%lld %d %d %d %d\n", copy, center.x >> 4, center.z >> 4, center.x, center.z);
+            }
+            /*std::cout << "Portal room for Stronghold " << var7 << " is at " << center.x << " " << center.z << ", and there are " << data->pieceCnt << " pieces that were generated before the portal room itself.\n\n" << std::endl;*/
+        }
+        angle += 2 * PI / 3.0;
+    }
     }
 
 void doSeed(int64_t seed, int x, int z, LayerStack g, int* cache, Data* threadData, BoundingBox* boxCache) {
@@ -213,12 +213,12 @@ void doSeed(int64_t seed, int x, int z, LayerStack g, int* cache, Data* threadDa
 
 // Main code begins below
 int main(int argc, char **argv) {
-	fp = fopen("out.txt", "w+");
-	char* filename = "ocinput.txt";
-	initBiomes();
+    fp = fopen("out.txt", "w+");
+    char* filename = "ocinput.txt";
+    initBiomes();
 
         int64_t checkpointOffset = 0;
-	std::vector<std::thread> threads;
+    std::vector<std::thread> threads;
 
         #ifdef BOINC
             BOINC_OPTIONS options;
@@ -248,12 +248,12 @@ FILE *checkpoint_data = boinc_fopen("filter9000-checkpoint.txt", "rb");
     }
 
     #ifdef BOINC
-	APP_INIT_DATA aid;
-	boinc_get_init_data(aid);
+    APP_INIT_DATA aid;
+    boinc_get_init_data(aid);
     #endif
 
-	std::string line;
-	std::ifstream infile(filename);
+    std::string line;
+    std::ifstream infile(filename);
 
     while(std::getline(infile, line)){
         int ChunkX = 0;
@@ -274,32 +274,32 @@ FILE *checkpoint_data = boinc_fopen("filter9000-checkpoint.txt", "rb");
     int ChunkZ;
 
     int* cache = (int*)malloc(sizeof(int) * 16 * 256 * 256);
-	Data* data = new Data();
-	BoundingBox* boxCache = (BoundingBox*)malloc(sizeof(BoundingBox));
+    Data* data = new Data();
+    BoundingBox* boxCache = (BoundingBox*)malloc(sizeof(BoundingBox));
 
-	LayerStack g;
-	setupGenerator(&g, MC_1_7);
+    LayerStack g;
+    setupGenerator(&g, MC_1_7);
 
     for(int i = 0+checkpointOffset; i < total; i++){
         time_t elapsed = time(NULL) - start;
-		std::string line = arr[i];
+        std::string line = arr[i];
         std::istringstream iss(line);
         if(!(iss >> structureSeed >> ChunkX >> ChunkZ)){break;}
 
-	for (int64_t upperBits = 0; upperBits < 1L << 16; upperBits++) {
-		int64_t worldSeed = (upperBits << 48) | structureSeed;
-		applySeed(&g, worldSeed);
-		doSeed(worldSeed, ChunkX, ChunkZ, g, cache, data, boxCache);
+    for (int64_t upperBits = 0; upperBits < 1L << 16; upperBits++) {
+        int64_t worldSeed = (upperBits << 48) | structureSeed;
+        applySeed(&g, worldSeed);
+        doSeed(worldSeed, ChunkX, ChunkZ, g, cache, data, boxCache);
             }
 
         if(i % 5 || boinc_time_to_checkpoint()){
             #ifdef BOINC
-		boinc_begin_critical_section(); // Boinc should not interrupt this
+        boinc_begin_critical_section(); // Boinc should not interrupt this
             #endif
         // Checkpointing section below
-		boinc_delete_file("filter9000-checkpoint.txt"); // Don't touch, same func as normal fdel
+        boinc_delete_file("filter9000-checkpoint.txt"); // Don't touch, same func as normal fdel
 
-	FILE *checkpoint_data = boinc_fopen("filter9000-checkpoint.txt", "wb");
+    FILE *checkpoint_data = boinc_fopen("filter9000-checkpoint.txt", "wb");
             struct checkpoint_vars data_store;
             data_store.offset = i;
             data_store.elapsed_chkpoint = elapsed_chkpoint + elapsed;


### PR DESCRIPTION
All tabs related to Stronghold simulation are now using 4 spaces instead of 1 tab.