### PR TITLE
fix(onechunk): initialize the simulation

### DIFF
--- a/filter9000-boinc.cpp
+++ b/filter9000-boinc.cpp
@@ -154,6 +154,11 @@ void getStrongholdPositions(LayerStack* g, int64_t* worldSeed, int SH, Data* dat
         x = biomePos.x >> 4;
         z = biomePos.z >> 4;
 
+        data->seed = copy;
+        data->StartChunkX = x;
+        data->StartChunkZ = z;
+        setInitialRng(data);
+        
         PieceInfo lastPiece = getLastPiece(data, copy, x, z);
         if(lastPiece.componentType == PORTALROOM_PIECE) {
             int pos1X, pos1Z, pos2X, pos2Z;

--- a/filter9000-boinc.cpp
+++ b/filter9000-boinc.cpp
@@ -194,7 +194,7 @@ void getStrongholdPositions(LayerStack* g, int64_t* worldSeed, int SH, Data* dat
             if((pos1X - 8) >> 4 == desiredX && (pos2X - 8) >> 4 == desiredX) {
                 if((pos1Z - 8) >> 4 == desiredZ && (pos2Z - 8) >> 4 == desiredZ) {
                     Position center = getCenterPos(lastPiece.box);
-                    fprintf(fp, "%lld %d %d %d %d\n", copy, center.x >> 4, center.z >> 4, center.x, center.z);
+                    fprintf(fp, "%lld %d %d\n", copy, center.x, center.z);
                     outCount++;
                 }
             }


### PR DESCRIPTION
Forgot calling setInitialRng, which makes the simulation rely on undefined behavior.