### PR TITLE
feat(onechunk): don't run stronghold sim for impossible positions.

### DIFF
--- a/filter9000-boinc.cpp
+++ b/filter9000-boinc.cpp
@@ -152,6 +152,11 @@ void getStrongholdPositions(LayerStack* g, int64_t* worldSeed, int SH, Data* dat
         x = biomePos.x >> 4;
         z = biomePos.z >> 4;
 
+        if(x < desiredX - 7 || x > desiredX + 7 || z < desiredZ - 7 || z > desiredZ + 7) {
+            angle += 2 * PI / 3.0;
+            continue;
+        }
+        
         data->seed = copy;
         data->StartChunkX = x;
         data->StartChunkZ = z;


### PR DESCRIPTION
The stronghold start pos must be inside a 7 chunk square radius of the desired position for the portal room to be able to end up in the desired chunk, so we can skip simulating strongholds that are not inside that boundary.